### PR TITLE
Ignore body-max-line-length in commitlint config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # NakoBase's project template
+
+## Usage
+
+Use this [package](https://github.com/nakobase/nakobase-template-sync) to sync this template to your projects.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,4 +5,5 @@
 
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  'body-max-line-length': [0, 'always'],
 };

--- a/templates/automated-release/README.md
+++ b/templates/automated-release/README.md
@@ -1,6 +1,6 @@
 # Automated Release
 
-Effortless continuous automated releases using [semantic-release](https://github.com/semantic-release) and []
+Effortless continuous automated releases using [semantic-release](https://github.com/semantic-release)
 
 # Usage
 
@@ -15,4 +15,4 @@ pnpm add -D semantic-release @semantic-release/changelog @semantic-release/git @
 1. Put `.releaserc.js` in the root of your project
 2. Put `.pr-release-template` in the root of your project
 3. Put `.github/workflows/release.yml` in the root of your project
-3. Put `.github/workflows/create-release-pr.yml` in the root of your project
+4. Put `.github/workflows/create-release-pr.yml` in the root of your project

--- a/templates/lint/commitlint/README.md
+++ b/templates/lint/commitlint/README.md
@@ -7,7 +7,7 @@ Commit conventions allow your team to add more semantic meaning to your git hist
 ## Package Installation
 
 ```bash
-pnpmn add -D @commitlint/{cli,config-conventional} husky
+pnpm add -D @commitlint/{cli,config-conventional} husky
 ```
 
 ## Configuration

--- a/templates/lint/commitlint/commitlint.config.js
+++ b/templates/lint/commitlint/commitlint.config.js
@@ -5,4 +5,5 @@
 
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  'body-max-line-length': [0, 'always'],
 };


### PR DESCRIPTION
## Description

Since `body-max-line-length` is not important rule, ignore it.

## Changes

- Update `commitlint.config.js`
- Update README files

## Related Issue

- close #6 

## Checklist

- [x] I have tested the code and it works as expected
- [x] I have run the tests and they pass successfully
- [x] I have updated the documentation as necessary
- [x] The code adheres to the project's code style guidelines

## Additional Information

None.
