### PR TITLE
fix: add rules key to commitlint.config.js

### DIFF
--- a/templates/lint/commitlint/commitlint.config.js
+++ b/templates/lint/commitlint/commitlint.config.js
@@ -5,5 +5,7 @@
 
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  'body-max-line-length': [0, 'always'],
+  rules: {
+    'body-max-line-length': [0, 'always'],
+  }
 };


### PR DESCRIPTION
## Description

`rules` key missing in commitlint.config.js.

## Changes

- List the key changes in this pull request
    - add `rules` key

## Related Issue

- #9 

## Checklist

- [x] I have tested the code and it works as expected
- [x] I have run the tests and they pass successfully
- [x] I have updated the documentation as necessary
- [x] The code adheres to the project's code style guidelines

## Additional Information

None.
